### PR TITLE
Add a selector to filter out pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ NAMESPACE   NAME    NODE                          REGION         ZONE
 ns-1        nginx   gke-gke-1-p-1-7023cbca-cz4b   europe-west1   europe-west1-c
 ```
 
+You can filter out pods using label selectors with the usual syntax:
+
+```shell
+$ kubectl topology pod --all-namespaces --region europe-west1 --selector k8s-app=kube-dns
+NAMESPACE     NAME                                     NODE                          REGION         ZONE
+kube-system   kube-dns-5f886bf8d8-s7pcc                gke-gke-1-p-1-50120dfc-26gm   europe-west1   europe-west1-d
+kube-system   kube-dns-5f886bf8d8-zhm42                gke-gke-1-p-1-8e1077f6-17st   europe-west1   europe-west1-b
+kube-system   kube-dns-autoscaler-8687c64fc-d5jvm      gke-gke-1-p-1-8e1077f6-17st   europe-west1   europe-west1-b
+```
+
 **NOTE:** `--region` and `--zone` are mutually exclusive.
 
 ## License

--- a/internal/cmd/pod.go
+++ b/internal/cmd/pod.go
@@ -24,6 +24,7 @@ import (
 func init() {
 	rootCmd.AddCommand(podCmd)
 	podCmd.PersistentFlags().BoolP("all-namespaces", "A", false, "List pods across all namespaces.")
+	podCmd.PersistentFlags().StringP("selector", "l", "", "A label selector to filter out pods.")
 }
 
 var podCmd = &cobra.Command{
@@ -41,11 +42,15 @@ var podCmd = &cobra.Command{
 		}
 		r, _ := cmd.Flags().GetString("region")
 		z, _ := cmd.Flags().GetString("zone")
+		l, err := cmd.Flags().GetString("selector")
+		if err != nil {
+			return err
+		}
 		o, err := util.NewTopologyOptions(r, z, n)
 		if err != nil {
 			return err
 		}
-		p, err := util.ListPods(kubeClient, o)
+		p, err := util.ListPods(kubeClient, o, l)
 		if err != nil {
 			return err
 		}

--- a/internal/util/pods.go
+++ b/internal/util/pods.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func ListPods(kubeClient kubernetes.Interface, o *TopologyOptions) (PodList, error) {
+func ListPods(kubeClient kubernetes.Interface, o *TopologyOptions, s string) (PodList, error) {
 	n, err := ListNodes(kubeClient, o)
 	if err != nil {
 		return nil, err
@@ -28,6 +28,7 @@ func ListPods(kubeClient kubernetes.Interface, o *TopologyOptions) (PodList, err
 	for _, nn := range n {
 		p, err := kubeClient.CoreV1().Pods(o.Namespace).List(metav1.ListOptions{
 			FieldSelector: "spec.nodeName=" + nn.Name,
+			LabelSelector: s,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Hey - I added a simple `--selector/-l` to mimick the `kubectl` behavior and filter out pods based on a label selector.
Plays nice with empty/invalid conditions, should be good enough 😄 